### PR TITLE
Add server to share duty with Novus bonus

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ jobs:
       run: |
         Invoke-WebRequest -Uri https://goatcorp.github.io/dalamud-distrib/latest.zip -OutFile latest.zip
         Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev\"   
+    - name: Add Secret.cs
+      run: |
+        echo '${{ secrets.SECRETS_CS }}' > ZodiacBuddy/Secrets.cs
     - name: Build
       run: |
         dotnet restore -r win ${{ env.SOLUTION_NAME }}.sln

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vs/
 bin/
 obj/
+
+ZodiacBuddy/Secrets.cs

--- a/ZodiacBuddy/ConfigWindow.cs
+++ b/ZodiacBuddy/ConfigWindow.cs
@@ -88,12 +88,23 @@ namespace ZodiacBuddy
                 Service.Configuration.Save();
             }
 
+            ImGui.Separator();
+
+            var notifyBonusDuty = Service.Configuration.NovusConfiguration.NotifyLightBonusOnlyWhenEquipped;
+            if (ImGui.Checkbox("Notify duty with bonus only when Novus relic is equipped", ref notifyBonusDuty))
+            {
+                Service.Configuration.NovusConfiguration.NotifyLightBonusOnlyWhenEquipped = notifyBonusDuty;
+                Service.Configuration.Save();
+            }
+
             var playSound = Service.Configuration.NovusConfiguration.PlaySoundOnLightBonusNotification;
             if (ImGui.Checkbox("Play sound when notifying about light bonus", ref playSound))
             {
                 Service.Configuration.NovusConfiguration.PlaySoundOnLightBonusNotification = playSound;
                 Service.Configuration.Save();
             }
+
+            ImGui.Separator();
 
             var dontPlayRelicGlassAnimation = Service.Configuration.NovusConfiguration.DontPlayRelicGlassAnimation;
             if (ImGui.Checkbox("Skip text animation from the relic glass", ref dontPlayRelicGlassAnimation))

--- a/ZodiacBuddy/Service.cs
+++ b/ZodiacBuddy/Service.cs
@@ -92,5 +92,10 @@ namespace ZodiacBuddy
         /// </summary>
         [PluginService]
         internal static ToastGui Toasts { get; private set; } = null!;
+
+        /// <summary>
+        /// Gets the sound manager.
+        /// </summary>
+        internal static Sound Sound { get; private set; } = new();
     }
 }

--- a/ZodiacBuddy/Sound.cs
+++ b/ZodiacBuddy/Sound.cs
@@ -1,0 +1,58 @@
+﻿using Dalamud.Utility.Signatures;
+
+namespace ZodiacBuddy
+{
+    /// <summary>
+    /// Manager to play sound.
+    /// </summary>
+    public class Sound
+    {
+        [Signature("E8 ?? ?? ?? ?? 4D 39 BE")]
+        private readonly AlertFuncDelegate playSound = null!;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Sound"/> class.
+        /// </summary>
+        public Sound()
+        {
+            SignatureHelper.Initialise(this);
+        }
+
+        private delegate ulong AlertFuncDelegate(Sounds id, ulong unk1, ulong unk2);
+
+        /// <summary>
+        /// List of sounds that can be played.
+        /// Correspond of '&lt;se.X&gt;' in-game.
+        /// </summary>
+        #pragma warning disable format,SA1602
+        public enum Sounds : byte
+        {
+            Sound01 = 0x25,
+            Sound02 = 0x26,
+            Sound03 = 0x27,
+            Sound04 = 0x28,
+            Sound05 = 0x29,
+            Sound06 = 0x2A,
+            Sound07 = 0x2B,
+            Sound08 = 0x2C,
+            Sound09 = 0x2D,
+            Sound10 = 0x2E,
+            Sound11 = 0x2F,
+            Sound12 = 0x30,
+            Sound13 = 0x31,
+            Sound14 = 0x32,
+            Sound15 = 0x33,
+            Sound16 = 0x34,
+        }
+        #pragma warning restore format,SA1602
+
+        /// <summary>
+        /// Play the asked sound.
+        /// </summary>
+        /// <param name="sound">Sound to play.</param>
+        public void PlaySound(Sounds sound)
+        {
+            this.playSound.Invoke(sound, 0, 0);
+        }
+    }
+}

--- a/ZodiacBuddy/Stages/Novus/Data/Report.cs
+++ b/ZodiacBuddy/Stages/Novus/Data/Report.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace ZodiacBuddy.Stages.Novus.Data
+{
+    /// <summary>
+    /// Report strut to communicate with the server.
+    /// </summary>
+    public struct Report
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Report"/> struct.
+        /// </summary>
+        /// <param name="datacenter">Datacenter id.</param>
+        /// <param name="world">World id.</param>
+        /// <param name="territory">Territory id.</param>
+        /// <param name="date">Date of the report.</param>
+        public Report(uint datacenter, uint world, uint territory, DateTime date)
+        {
+            this.Datacenter = datacenter;
+            this.World = world;
+            this.Territory = territory;
+            this.Date = date;
+        }
+
+        /// <summary>
+        /// Gets Datacenter id.
+        /// </summary>
+        public uint Datacenter { get; }
+
+        /// <summary>
+        /// Gets World id.
+        /// </summary>
+        public uint World { get; }
+
+        /// <summary>
+        /// Gets territory id.
+        /// </summary>
+        public uint Territory { get; }
+
+        /// <summary>
+        /// Gets report date.
+        /// </summary>
+        public DateTime Date { get; }
+    }
+}

--- a/ZodiacBuddy/Stages/Novus/Data/Report.cs
+++ b/ZodiacBuddy/Stages/Novus/Data/Report.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+using Newtonsoft.Json;
+
 namespace ZodiacBuddy.Stages.Novus.Data
 {
     /// <summary>
@@ -10,36 +12,40 @@ namespace ZodiacBuddy.Stages.Novus.Data
         /// <summary>
         /// Initializes a new instance of the <see cref="Report"/> struct.
         /// </summary>
-        /// <param name="datacenter">Datacenter id.</param>
-        /// <param name="world">World id.</param>
-        /// <param name="territory">Territory id.</param>
+        /// <param name="datacenterId">Datacenter id.</param>
+        /// <param name="worldId">World id.</param>
+        /// <param name="territoryId">Territory id.</param>
         /// <param name="date">Date of the report.</param>
-        public Report(uint datacenter, uint world, uint territory, DateTime date)
+        public Report(uint datacenterId, uint worldId, uint territoryId, DateTime date)
         {
-            this.Datacenter = datacenter;
-            this.World = world;
-            this.Territory = territory;
+            this.DatacenterId = datacenterId;
+            this.WorldId = worldId;
+            this.TerritoryId = territoryId;
             this.Date = date;
         }
 
         /// <summary>
-        /// Gets Datacenter id.
+        /// Gets or sets datacenter id.
         /// </summary>
-        public uint Datacenter { get; }
+        [JsonProperty("datacenter_id")]
+        public uint DatacenterId { get; set; }
 
         /// <summary>
-        /// Gets World id.
+        /// Gets or sets world id.
         /// </summary>
-        public uint World { get; }
+        [JsonProperty("world_id")]
+        public uint WorldId { get; set; }
 
         /// <summary>
-        /// Gets territory id.
+        /// Gets or sets territory id.
         /// </summary>
-        public uint Territory { get; }
+        [JsonProperty("territory_id")]
+        public uint TerritoryId { get; set; }
 
         /// <summary>
-        /// Gets report date.
+        /// Gets or sets report date.
         /// </summary>
-        public DateTime Date { get; }
+        [JsonProperty("date")]
+        public DateTime Date { get; set; }
     }
 }

--- a/ZodiacBuddy/Stages/Novus/NovusConfiguration.cs
+++ b/ZodiacBuddy/Stages/Novus/NovusConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace ZodiacBuddy.Novus;
 
@@ -14,6 +15,18 @@ public class NovusConfiguration
     private static readonly uint DefaultProgressColor = 0xFF943463;
 
     /// <summary>
+    /// Gets or sets the Territory Id of the current duty with bonus of light.
+    /// </summary>
+    [JsonIgnore]
+    public uint? LightBonusTerritoryId { get; set; }
+
+    /// <summary>
+    /// Gets or sets UTC time of detection of the current duty with bonus of light.
+    /// </summary>
+    [JsonIgnore]
+    public DateTime? LightBonusDetection { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether to display the information about the Novus weapons.
     /// </summary>
     public bool DisplayNovusInfo { get; set; } = true;
@@ -27,16 +40,6 @@ public class NovusConfiguration
     /// Gets or sets the color of the progress bar on Novus weapons information.
     /// </summary>
     public uint ProgressColor { get; set; } = DefaultProgressColor;
-
-    /// <summary>
-    /// Gets or sets the Territory Id of the current duty with bonus of light.
-    /// </summary>
-    public uint? LightBonusTerritoryId { get; set; }
-
-    /// <summary>
-    /// Gets or sets UTC time of detection of the current duty with bonus of light.
-    /// </summary>
-    public DateTime? LightBonusDetection { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to show the actual numbers in the RelicGlass addon.

--- a/ZodiacBuddy/Stages/Novus/NovusConfiguration.cs
+++ b/ZodiacBuddy/Stages/Novus/NovusConfiguration.cs
@@ -44,6 +44,11 @@ public class NovusConfiguration
     public bool ShowNumbersInRelicGlass { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to notify the user of new duty with bonus light when the relic is not equipped.
+    /// </summary>
+    public bool NotifyLightBonusOnlyWhenEquipped { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether to not display the first message on the RelicGlass addon.
     /// </summary>
     public bool DontPlayRelicGlassAnimation { get; set; } = true;

--- a/ZodiacBuddy/Stages/Novus/NovusHttpClient.cs
+++ b/ZodiacBuddy/Stages/Novus/NovusHttpClient.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+using Dalamud.Game.ClientState;
+using Dalamud.Logging;
+using Newtonsoft.Json;
+using ZodiacBuddy.Novus;
+using ZodiacBuddy.Novus.Data;
+using ZodiacBuddy.Stages.Novus.Data;
+
+namespace ZodiacBuddy.Stages.Novus
+{
+    /// <summary>
+    /// Http client to share and retrieve reports about duty with Novus bonus of light.
+    /// </summary>
+    internal class NovusHttpClient : IDisposable
+    {
+        private const string BaseUri = "https://sparkling-glade-8937.fly.dev";
+        private readonly HttpClient httpClient;
+        private readonly ClientState clientState;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NovusHttpClient"/> class.
+        /// </summary>
+        public NovusHttpClient()
+        {
+            this.httpClient = new HttpClient();
+            this.clientState = Service.ClientState;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.httpClient.Dispose();
+        }
+
+        /// <summary>
+        /// Retrieve the last report about light bonus for the current datacenter.
+        /// </summary>
+        public void RetrieveLastReport()
+        {
+            if (this.clientState.LocalPlayer == null)
+                return;
+            if (this.clientState.LocalPlayer.HomeWorld.GameData == null)
+                return;
+            var datacenter = this.clientState.LocalPlayer.HomeWorld.GameData.DataCenter.Row;
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUri}/reports/last/{datacenter}");
+
+            this.Send(request, this.OnLastReportResponse);
+        }
+
+        /// <summary>
+        /// Send a new report to the server.
+        /// </summary>
+        /// <param name="territoryId">Id of the duty with the light bonus.</param>
+        public void SendReport(uint territoryId)
+        {
+            if (this.clientState.LocalPlayer == null)
+                return;
+            if (this.clientState.LocalPlayer.HomeWorld.GameData == null)
+                return;
+            var datacenter = this.clientState.LocalPlayer.HomeWorld.GameData.DataCenter.Row;
+            var world = this.clientState.LocalPlayer.HomeWorld.Id;
+
+            var report = new Report(datacenter, world, territoryId, DateTime.UtcNow);
+            var content = JsonConvert.SerializeObject(report);
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{BaseUri}/reports/");
+            request.Content = new StringContent(content, Encoding.UTF8, "application/json");
+
+            this.Send(request, null);
+        }
+
+        private void Send(HttpRequestMessage request, Action<HttpResponseMessage>? callback)
+        {
+            Task.Run(() =>
+            {
+                var response = this.httpClient.Send(request);
+                callback?.Invoke(response);
+            });
+        }
+
+        private async void OnLastReportResponse(HttpResponseMessage response)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            PluginLog.Debug($"{response.StatusCode} => {content}");
+            if (!response.IsSuccessStatusCode)
+                return;
+
+            var report = JsonConvert.DeserializeObject<Report>(content);
+            var dt = DateTime.UtcNow.Subtract(TimeSpan.FromHours(2));
+            if (report.Date >= dt && NovusDuty.TryGetValue(report.Territory, out var territoryLight))
+            {
+                var message = $"Light bonus detected on \"{territoryLight?.DutyName}\"";
+                NovusManager.UpdateLightBonus(report.Territory, report.Date, message);
+            }
+        }
+    }
+}

--- a/ZodiacBuddy/Stages/Novus/NovusWindow.cs
+++ b/ZodiacBuddy/Stages/Novus/NovusWindow.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Numerics;
+﻿using System.Numerics;
 
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
@@ -84,11 +83,8 @@ public class NovusWindow
         if (!Configuration.DisplayBonusDuty)
             return;
 
-        // Don't display bonus light detected 2h ago
-        var dt = DateTime.UtcNow.Subtract(TimeSpan.FromHours(2));
         if (Configuration.LightBonusDetection != null &&
-            Configuration.LightBonusTerritoryId != null &&
-            Configuration.LightBonusDetection.Value > dt)
+            Configuration.LightBonusTerritoryId != null)
         {
             var dutyName = NovusDuty.GetValue(Configuration.LightBonusTerritoryId.Value).DutyName;
             var detectionDate = Configuration.LightBonusDetection.Value.ToLocalTime().ToString("t");

--- a/ZodiacBuddy/Stages/Novus/NovusWindow.cs
+++ b/ZodiacBuddy/Stages/Novus/NovusWindow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Numerics;
+
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using FFXIVClientStructs.FFXIV.Client.Game;

--- a/ZodiacBuddy/ZodiacBuddy.csproj
+++ b/ZodiacBuddy/ZodiacBuddy.csproj
@@ -50,6 +50,9 @@
     <!--<PackageReference Include="DalamudLinter" Version="1.0.3" />-->
     <PackageReference Include="DalamudPackager" Version="2.1.6" />
     <PackageReference Include="ILRepack" Version="2.0.18" GeneratePathProperty="true" />
+    <PackageReference Include="JWT" Version="9.0.3" />
+    <!-- Provided by Dalamud -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" ExcludeAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### Feature
 * Add client side to communicate with [ZodiacBuddyDB](https://github.com/Hiroa/ZodiacBuddyDB) (Hope the name is not a problem)
 * Move the "playSound" function to a separate class
 * Change the way that the duty light bonus is reset (every even UTC hours)

The server is hosted on [Fly.io](https://fly.io/) with the free plan for now.  
The communication are verified by jwt so a SECRETS_CS is needed on the repo secrets with the same key than the server.
