### PR TITLE
Change how novus light bonus is detected #26

### DIFF
--- a/ZodiacBuddy/BonusLight/BonusLightConfiguration.cs
+++ b/ZodiacBuddy/BonusLight/BonusLightConfiguration.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Newtonsoft.Json;
 
@@ -15,12 +14,6 @@ public class BonusLightConfiguration
     /// </summary>
     [JsonIgnore]
     public List<uint> ActiveBonus { get; } = new();
-
-    /// <summary>
-    /// Gets the list of Territory Id of duty with bonus of light on the previous 2 hours.
-    /// </summary>
-    [JsonIgnore]
-    public List<uint> PreviousBonus { get; } = new();
 
     /// <summary>
     /// Gets or sets a value indicating whether to display the current duty with light bonus on the Novus information window.

--- a/ZodiacBuddy/Stages/Brave/BraveManager.cs
+++ b/ZodiacBuddy/Stages/Brave/BraveManager.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 
 using Dalamud.Game;
-using Dalamud.Game.Gui.Toast;
-using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Hooking;
 using Dalamud.Logging;
 using Dalamud.Utility.Signatures;
@@ -50,11 +48,10 @@ internal class BraveManager : IDisposable
 
     private static BraveConfiguration Configuration => Service.Configuration.Brave;
 
-    private static BonusLightConfiguration LightConfiguration => Service.Configuration.BonusLight;
-
     /// <inheritdoc/>
     public void Dispose()
     {
+        Service.Framework.Update -= this.OnUpdate;
         Service.Interface.UiBuilder.Draw -= this.window.Draw;
 
         this.addonRelicMagiciteOnSetupHook?.Disable();


### PR DESCRIPTION
Allow same duty to be detected in successive light window.  
Improve report detection time to prevent overflow.

I don't have any weapon currently to test if I broke anything.